### PR TITLE
Update alert dialog import

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -11,7 +11,6 @@ package com.facebook.react.modules.dialog;
 
 import javax.annotation.Nullable;
 
-//import android.app.AlertDialog;
 import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -11,7 +11,8 @@ package com.facebook.react.modules.dialog;
 
 import javax.annotation.Nullable;
 
-import android.app.AlertDialog;
+//import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;


### PR DESCRIPTION
/cc: @farazs 

This is the PR for new branch `0.42-ipsy_fork_1.0.1`.

Fix the button not fully shown issue on RatingReminder. This issue only happens on Samsung S5 so far with OS version 5.0. 

![screenshot_2017-03-17-18-24-05 1](https://cloud.githubusercontent.com/assets/7017516/24267622/226fb6a6-0fc8-11e7-8473-7e3b7bfa65b4.png)
![screenshot_2017-03-23-16-10-45](https://cloud.githubusercontent.com/assets/7017516/24268358/c17ae73c-0fca-11e7-980e-40c4cc176254.png)
